### PR TITLE
Correction of the autocorrelation estimate

### DIFF
--- a/TOATS.ipynb
+++ b/TOATS.ipynb
@@ -134,9 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Date format test\n",
@@ -226,9 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def decimal_month(years, months, days):\n",
@@ -279,9 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# calculate and display monthly and annual statistics\n",
@@ -457,9 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# create series of dates adjusted to start at 0 for use in the regression model \n",
@@ -489,9 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# calculate and plot trend \n",
@@ -526,17 +516,21 @@
    "outputs": [],
    "source": [
     "TDTi_dict = {}  # time of detection\n",
-    "# autocorrelation at lag 1 of the time series noise\n",
-    "for k, v in wls_model_dict.items():\n",
-    "    ts_variable_deseasoned = v['ts_variable_deseasoned']\n",
-    "    decimal_year_zero = v['decimal_year_zero']\n",
-    "    autocorr = sm.tsa.stattools.acf(ts_variable_deseasoned,fft=False,nlags=1)[1:]\n",
-    "    ts_mean = var_trends[k]['ts_mean']\n",
     "\n",
-    "    # standard deviation of detrended monthly anomalies\n",
+    "for k, v in wls_model_dict.items():\n",
     "    model = v['model']\n",
+    "    ts_mean = var_trends[k]['ts_mean']\n",
+    "    decimal_year_zero = v['decimal_year_zero']\n",
+    "    ts_variable_deseasoned = v['ts_variable_deseasoned']\n",
+    "    \n",
+    "    # Detrended monthly anomalies\n",
     "    trend_to_remove_TDT = model.predict(decimal_year_zero)\n",
     "    detrended_TDT = [ts_variable_deseasoned[i]-trend_to_remove_TDT[i] for i in range(0, len(ts_mean[k]['datetime_mean']))]\n",
+    "    \n",
+    "    # autocorrelation at lag 1 of the time series noise (i.e. detrended monthly anomalies) \n",
+    "    autocorr = sm.tsa.stattools.acf(detrended_TDT,fft=False,nlags=1)[1:]\n",
+    "\n",
+    "    # standard deviation of detrended monthly anomalies\n",
     "    std_dev = np.std(detrended_TDT)\n",
     "\n",
     "    # time of detection \n",
@@ -617,9 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# summary of OLS Regression Results\n",
@@ -767,9 +759,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I found your article very instructive and very useful because it's supplemented by the code, which makes it easy to understand the method. This has helped me a lot in my current project.

When reading the code, I observed a variation from the TDT formula previously published by Weatherhead et al, 1998 and Tiao et al, 1990 as well as Henson et al., 2016.

They define the noise as the residual of the signal, i.e. the detrended data. However , in the code, autocorrelation is estimated solely on the basis of deseasonalised data.

According to a basic statistical model of a time series, we have :
Y_t = b + **a**X_t + **S**_t + **N**_t

So the time series (Yt) is composed of : 
-	low frequencies (annual, decadal...) of magnitude equal to '**a**' which constitute the trend (**a**X_t), 
-	“higher frequencies” represented by the seasonality which theoretically can be sinusoidal (so that the seasonality **S**_t= amplitude * sin((2*pi/frequency)*t. The frequency can be equal to 6 if we have monthly time series and the seasonality is semi-annual), 
-	and unexplained frequencies which constitute noise (**N**_t, the unexplained part of the time series).
 
So the noise is the result of subtracting different frequencies from the time series Y_t (if we assume that the intercept b=0 to simplify the task):
**N**_t = Y_t - **a**X_t – **S**_t
 
So the uncertainty in the trend comes from the unexplained frequencies, i.e. the noise. 
 
On the other hand, according to the articles of Weatherhead et al, 1998 and Tiao et al, 1990, the noise (**N**_t) is not completely unexplained (i.e. not completely random), it also follows a regression model which is a first-order autoregressive model (AR(1)), so that the noise at time t=1 can be correlated and explained by the noise at time t=0:
**N**_t = **phi** * **N**_t-1 + **e**_t
 
And,
The completely random and unexplained part lies in the ' **e**_t' term, which is therefore white noise by definition. So **phi** **(the autocorrelation)** is a function of **N**_t, **N**_t-1 and et. To get rid of **e**_t, they deduce a relationship between the Standard deviation of the trend estimate, the standard deviation of the noise and the standard deviation of **e**_t .
